### PR TITLE
Updated AN00217 to include rather than copy code

### DIFF
--- a/examples/AN00217_app_high_resolution_delay_example/doc/rst/AN00217.rst
+++ b/examples/AN00217_app_high_resolution_delay_example/doc/rst/AN00217.rst
@@ -21,9 +21,11 @@ your ``Makefile``::
         USED_MODULES = ... lib_mic_array ...
 
 You can then access the microphone array library functions in your source code via
-the ``lib_mic_array.h`` header file::
+the ``lib_mic_array.h`` header file:
 
-	#include "lib_mic_array.h"
+.. literalinclude:: app_high_resolution_delay_example.xc
+   :start-on: include "mic_array.h"
+   :end-before: on tile
 
 Demo Hardware Setup
 ------------------- 
@@ -62,23 +64,12 @@ the application.This gives the following task diagram:
 	    
 	Task diagram of the example
 
-Or represented in code as::
+Or represented in code as:
 
-  streaming chan c_pdm_to_hires[2];
-  streaming chan c_hires_to_dec[2];
-  streaming chan c_ds_output[2];
-  chan c_cmd;
+.. literalinclude:: app_high_resolution_delay_example.xc
+   :start-on: streaming chan c_pdm_to_hires[2];
+   :end-on: example(c_ds_output, c_cmd);
 
-  ...
-
-  par{
-    pdm_rx(p_pdm_mics, c_pdm_to_hires[0], c_pdm_to_hires[1]);
-    hires_delay(c_pdm_to_hires, c_hires_to_dec, 2, c_cmd);
-    decimate_to_pcm_4ch(c_hires_to_dec[0], c_ds_output[0]);
-    decimate_to_pcm_4ch(c_hires_to_dec[1], c_ds_output[1]);
-    example(c_ds_output, c_cmd);
-  }
-	
 Note that the decimators have to be on the same tile as the application due to shared frame memory.	
 Finally, there needs to be a channel between the ``hires_delay`` and the application in order to issue
 the commands to change the taps on each delay line.
@@ -91,10 +82,11 @@ block must be::
   
   Number of channels for that decimator * THIRD_STAGE_COEFS_PER_STAGE * Decimation factor * sizeof(int)
 
-bytes. The data must also be double word aligned. For example::
+bytes. The data must also be double word aligned. For example:
 
-  int data_0[4*THIRD_STAGE_COEFS_PER_STAGE*DF] = {0};
-  int data_1[4*THIRD_STAGE_COEFS_PER_STAGE*DF] = {0};
+.. literalinclude:: app_high_resolution_delay_example.xc
+   :start-on: int data_0
+   :end-on: int data_1
 
 Also the frame memory must also be a double word aligned array of length of at least 2.
 Note that on the xCORE-200 all global arrays are guaranteed to be double-word aligned.
@@ -102,45 +94,25 @@ Note that on the xCORE-200 all global arrays are guaranteed to be double-word al
 Configuration
 -------------
 
-Configuration for the example is achieved through::
+Configuration for the example is achieved through:
 
-   decimator_config_common dcc = {
-                  0, // Frame size log 2 is set to 0, i.e. one sample per channel will be present in each frame
-                  1, // DC offset elimination is turned on
-                  0, // Index bit reversal is off
-                  0, // No windowing function is being applied
-                  DF,// The decimation factor is set to 6
-                  g_third_16kHz_fir, //This corresponds to a 16kHz output hence this coef array is used
-                  0, // Gain compensation is turned off
-                  0  // FIR compensation is turned offspecified to be 
-                  DECIMATOR_NO_FRAME_OVERLAP, //Frame over lapping is turned off
-                  2  // There are 2 buffers in the audio array
-          };
-          decimator_config dc[2] = {
-                  {
-                          &dcc,
-                          data_0,     // The storage area for the output decimator
-                          {INT_MAX, INT_MAX, INT_MAX, INT_MAX},  // Microphone gain compensation (turned off)
-                          4           // Enabled channel count
-                  },
-                  {
-                          &dcc,
-                          data_1,     // The storage area for the output decimator
-                          {INT_MAX, INT_MAX, INT_MAX, INT_MAX}, // Microphone gain compensation (turned off)
-                          4           // Enabled channel count
-                  }
-          };
-          decimator_configure(c_ds_output, 2, dc);
+.. literalinclude:: app_high_resolution_delay_example.xc
+   :start-on: decimator_config_common
+   :end-on: decimator_configure
 
 All configuration options are enumerated in the Microphone array library. Once configured 
-then the decimators require initialization via::
+then the decimators require initialization via:
   
-  decimator_init_audio_frame(c_ds_output, 2, buffer, audio, dcc);
+.. literalinclude:: app_high_resolution_delay_example.xc
+   :start-on: decimator_init_audio_frame
+   :end-before: while(1)
 
-The the decimators will start presenting samples in the form of frames that can be accessed with::
+The the decimators will start presenting samples in the form of frames that can be accessed with:
 
-  frame_audio *current = decimator_get_next_audio_frame(c_ds_output, 2, buffer, audio, 2);
-  
+.. literalinclude:: app_high_resolution_delay_example.xc
+   :start-on: decimator_get_next
+   :end-before: buffer and audio
+
 The return value of the above is a pointer to the frame that the application (``example()``) is allowed 
 to access. The ``current`` structure contains the frame data in the ``data`` member. ``data`` is a 2D array
 with the first index denoting the channel number and the second index denoting the frame index. The frame

--- a/examples/AN00217_app_high_resolution_delay_example/src/app_high_resolution_delay_example.xc
+++ b/examples/AN00217_app_high_resolution_delay_example/src/app_high_resolution_delay_example.xc
@@ -68,33 +68,30 @@ void example(streaming chanend c_ds_output[2], streaming chanend c_cmd){
     }
 }
 
-int main(){
+int main() {
 
-    par{
+    par {
         on tile[0]: {
-            streaming chan c_pdm_to_hires[2];
-            streaming chan c_hires_to_dec[2];
-            streaming chan c_ds_output[2];
-            streaming chan c_cmd;
-
             configure_clock_src_divide(pdmclk, p_mclk, 4);
             configure_port_clock_output(p_pdm_clk, pdmclk);
             configure_in_port(p_pdm_mics, pdmclk);
             start_clock(pdmclk);
 
-            unsafe {
-                par{
-                    pdm_rx(p_pdm_mics, c_pdm_to_hires[0], c_pdm_to_hires[1]);
+            streaming chan c_pdm_to_hires[2];
+            streaming chan c_hires_to_dec[2];
+            streaming chan c_ds_output[2];
+            streaming chan c_cmd;
 
-                    hires_delay(c_pdm_to_hires,
-                            c_hires_to_dec, 2, c_cmd);
+            par {
+                pdm_rx(p_pdm_mics, c_pdm_to_hires[0], c_pdm_to_hires[1]);
 
-                    decimate_to_pcm_4ch(c_hires_to_dec[0], c_ds_output[0]);
-                    decimate_to_pcm_4ch(c_hires_to_dec[1], c_ds_output[1]);
+                hires_delay(c_pdm_to_hires,
+                        c_hires_to_dec, 2, c_cmd);
 
-                    example(c_ds_output, c_cmd);
-                    par(int i=0;i<3;i++)while(1);
-                }
+                decimate_to_pcm_4ch(c_hires_to_dec[0], c_ds_output[0]);
+                decimate_to_pcm_4ch(c_hires_to_dec[1], c_ds_output[1]);
+
+                example(c_ds_output, c_cmd);
             }
         }
     }


### PR DESCRIPTION
I've done another revision of this app note to stop the maintenance issue of copied code. It now pulls in the code using literalinclude.

I've also removed the par of 3 while(1) in the main and the unsafe both of which shouldn't be in this app note.
