### PR TITLE
Increment minor rather than point version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 lib_mic_array change log
 ========================
 
-3.0.3
+3.1.0
 -----
 
   * Modified the FIR designer to increase the first stage stopband attenuation.

--- a/lib_mic_array/module_build_info
+++ b/lib_mic_array/module_build_info
@@ -2,4 +2,4 @@ MODULE_XCC_XC_FLAGS = $(XCC_XC_FLAGS)
 
 DEPENDENT_MODULES = lib_xassert(>=3.0.0) lib_logging(>=2.1.0) lib_dsp(>=3.0.0)
 
-VERSION = 3.0.2
+VERSION = 3.1.0

--- a/lib_mic_array/src/fir/fir_coefs.h
+++ b/lib_mic_array/src/fir/fir_coefs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2016-2017, XMOS Ltd, All rights reserved
 extern const int g_first_stage_fir_0[256];
 extern const int g_first_stage_fir_1[256];
 extern const int g_first_stage_fir_2[256];

--- a/lib_mic_array/src/fir/fir_coefs.xc
+++ b/lib_mic_array/src/fir/fir_coefs.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2016-2017, XMOS Ltd, All rights reserved
 const int g_first_stage_fir_0[256] = {
 	0x007c8875, 0x0019620a, 0x00390209, 0xffd5db9f, 0x0052f4ad, 0xffefce43, 0x000f6e42, 0xffac47d7, 
 	0x00658a59, 0x000263ed, 0x002203ed, 0xffbedd83, 0x003bf691, 0xffd8d027, 0xfff87026, 0xff9549bb, 


### PR DESCRIPTION
`--use-low-ripple-first-stage` looks like a new feature in the FIR designer, rather than a bug fix to me?