### PR TITLE
Add asynchronous interface to decimators

### DIFF
--- a/lib_mic_array/api/mic_array.h
+++ b/lib_mic_array/api/mic_array.h
@@ -115,6 +115,9 @@ typedef struct {
 
     unsigned channel_count; /**< The count of enabled channels (0->4).  */
 
+    unsigned async_interface_enabled; /** If set to 1, this disables the mic_array_get_next_time_domain_frame interface
+                                        and enables the mic_array_recv_sample interface. **/
+
 } mic_array_decimator_config_t;
 
 typedef unsigned mic_array_internal_audio_channels;
@@ -173,6 +176,23 @@ void mic_array_init_far_end_channels(mic_array_internal_audio_channels internal_
  *
  */
 int mic_array_send_sample( streaming chanend c_to_decimator, int sample);
+
+
+/** This receives a pair of audio samples from a decimator. async_interface_enabled
+ * must be set in the decimator config for this function to work as intended.
+ *
+ * If this function isn't called at least at the rate at which the decimator is outputting samples
+ * it will cause timing related errors.
+ *
+ *  \param c_from_decimator  The channel used to transfer audio sample between
+ *                           the decimator and the application.
+ *  \param ch_a              The first audio sample to be received.
+ *  \param ch_b              The second audio sample to be received.
+ *  \returns                 0 for success and 1 for failure. Failure may occur when the decimators
+ *                           are not yet running or when a new sample isn't ready.
+ *
+ */
+int mic_array_recv_samples(streaming chanend c_from_decimator, int &ch_a, int &ch_b);
 
 /** Four Channel Decimation initializer for raw audio frames.
  *

--- a/lib_mic_array/src/decimate_to_pcm_4ch.S
+++ b/lib_mic_array/src/decimate_to_pcm_4ch.S
@@ -86,7 +86,10 @@
 #define S_FAR_END_CHANNEL_1     11
 #define S_FAR_END_CHANNEL_2     12
 #define S_FAR_END_CHANNEL_3     13
-#define S_STORAGE_SIZE 			14
+
+#define S_ASYNC_INTERFACE       14
+
+#define S_STORAGE_SIZE 			16
 
 //////////////////////////////////////////////////////////////////////////////////////
 //this address must be double word aligned
@@ -524,6 +527,9 @@ lengthDone:
 	{ldw r11, r2[6];} //channel count
 	stw r11, sp[S_CHAN_COUNT]
 
+	{ldw r11, r2[7];} // async interface enabled
+	stw r11, sp[S_ASYNC_INTERFACE]
+
 load_mic_gain_calib:
 	ldaw r1, sp[S_MIC_CALIB_OFFSET]
 	ldw r0, r2[2]
@@ -552,8 +558,8 @@ get_frame_pointer:
 
 	bt r5, overlapping
 	non_overlapping:
-	    {in r1, res[r2];stw r5, r11[S_OVERLAPPING_FRAMES]}
-	    {in r1, res[r2];stw r1, r11[S_FRAME_POINTER_0]}
+	    {in r1, res[r2];stw r5, r11[S_OVERLAPPING_FRAMES]} // frames pointer
+	    {in r1, res[r2];stw r1, r11[S_FRAME_POINTER_0]} // metadata pointer
 	    saving_non_overlapping_metadata_pointer:
 		{stw r1, r11[S_METADATA_POINTER_0];ldc r2, 0 }
 		std r2, r2, r1[0]	//init the sig bits
@@ -877,6 +883,9 @@ internal_channel_overwrite_begin:
 		{add r5, r5, 1;ldw r6, r4[S_OVERLAPPING_FRAMES]}
 		stw r5, r4[S_FRAME_0_INDEX]
 
+        ldw r11, sp[S_ASYNC_INTERFACE]
+        bt r11, async_send_samples
+
 		bt r6, overlapping_frames
 		no_overlapping_frames:
 
@@ -994,6 +1003,22 @@ internal_channel_overwrite_begin:
 				{outct res[r7], 8; stw r5, r4[S_METADATA_POINTER_1]}//WARNING: do not change this
 				std r0, r0, r5[0]  //reset the frame sig bits to 0
 				std r0, r0, r5[1]  //reset the frame sig bits to 0
+
+        async_send_samples:
+            ldc r6, 0
+            stw r6, r4[S_FRAME_0_INDEX]
+
+            ldw r9, sp[S_C_OUTPUT]
+            {ldc r5, 1<<(MIC_ARRAY_MAX_FRAME_SIZE_LOG2)}
+            {add r7, r6, r5; ldw r8, r4[S_FRAME_POINTER_0]}
+
+            ldw r10, r8[r7] // Load mic 1 sample
+            ldw r11, r8[r6] // Load mic 0 sample
+
+            out res[r9], r10
+            out res[r9], r11
+
+            bu do_the_rest
 
 	do_the_rest:
 	ldaw r11, sp[S_THIRD_STAGE]

--- a/lib_mic_array/src/decimator_interface.xc
+++ b/lib_mic_array/src/decimator_interface.xc
@@ -5,6 +5,10 @@
 
 #define XASSERT_UNIT DEBUG_MIC_ARRAY
 
+#define DEBUG_UNIT MIC_ARRAY
+#define DEBUG_PRINT_ENABLE_MIC_ARRAY 1
+#include "debug_print.h"
+
 #if DEBUG_MIC_ARRAY
 #include "xassert.h"
 #endif
@@ -20,12 +24,22 @@ void mic_array_init_far_end_channels(mic_array_internal_audio_channels ch[4],
     }
 }
 
-int mic_array_send_sample( streaming chanend c_to_decimator, int sample){
+int mic_array_send_sample(streaming chanend c_to_decimator, int sample){
     select {
         case c_to_decimator :> int:{
             c_to_decimator <: sample;
             return 0;
         }
+        default:
+            return 1;
+    }
+}
+
+int mic_array_recv_samples(streaming chanend c_from_decimator, int &ch_a, int &ch_b) {
+    select {
+        case c_from_decimator :> ch_a:
+            c_from_decimator :> ch_b;
+            return 0;
         default:
             return 1;
     }

--- a/lib_mic_array/src/decimator_interface.xc
+++ b/lib_mic_array/src/decimator_interface.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2019, XMOS Ltd, All rights reserved
 #include "mic_array.h"
 #include <xs1.h>
 #include <string.h>


### PR DESCRIPTION
Requires mic_array_recv_samples is called at least as fast as the decimators are producing samples. e.g. in sw_xvf3510, it's called at 48K in UserBufferManagement and the decimators are producing samples at 16K 