### PR TITLE
Fix compiler warning when MIC_DUAL_ENABLED is not defined

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_mic_array change log
 ========================
 
+4.2.3
+-----
+
+  * FIXED: Compiler warnings when MIC_DUAL_ENABLED is not defined
+
 4.2.2
 -----
 

--- a/lib_mic_array/module_build_info
+++ b/lib_mic_array/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 4.2.2
+VERSION = 4.2.3
 
 DEPENDENT_MODULES = lib_xassert(>=4.0.0) \
                     lib_logging(>=3.0.0) \

--- a/lib_mic_array/src/mic_array_dual.xc
+++ b/lib_mic_array/src/mic_array_dual.xc
@@ -279,6 +279,9 @@ static inline void ciruclar_buffer_sim_cpy(int * unsafe src_ptr, int * unsafe de
 }
 
 
+// If not MIC_DUAL_ENABLED, cause a link error
+#ifdef MIC_DUAL_ENABLED
+
 static int dc_eliminate(int x, int &prev_x, long long &state){
 #define S 0
 #define N 8
@@ -298,9 +301,6 @@ static int dc_eliminate(int x, int &prev_x, long long &state){
     return (state>>(32-S));
 }
 
-
-// If not MIC_DUAL_ENABLED, cause a link error
-#ifdef MIC_DUAL_ENABLED
 
 #pragma unsafe arrays
 void mic_dual_pdm_rx_decimate(buffered in port:32 p_pdm_mic, streaming chanend c_2x_pdm_mic, streaming chanend c_ref_audio[]){


### PR DESCRIPTION

```
/home/oscar/sandboxes/usb_audio/lib_mic_array/lib_mic_array/src/mic_array_dual.xc:282:12: warning: 'dc_eliminate' defined but not used [-Wunused-function]
static int dc_eliminate(int x, int &prev_x, long long &state){
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```