### PR TITLE
Update jenkins shared library version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.16.1') _
+@Library('xmos_jenkins_shared_library@v0.16.2') _
 getApproval()
 
 pipeline {


### PR DESCRIPTION
Fixes error with new get_pip.py url seen here: http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_mic_array/detail/develop/569/pipeline