### PR TITLE
Re-apply original copyright years

### DIFF
--- a/examples/app_vu/src/log2_lut.h
+++ b/examples/app_vu/src/log2_lut.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef LOG2_LUT_H_
 #define LOG2_LUT_H_

--- a/legacy_tests/test_mic_dual.py
+++ b/legacy_tests/test_mic_dual.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2016-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import xmostest
 import subprocess

--- a/legacy_tests/test_mic_dual/src/test_mic_dual.xc
+++ b/legacy_tests/test_mic_dual/src/test_mic_dual.xc
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <stdio.h>
 #include <xs1.h>

--- a/legacy_tests/test_mic_dual_timing.py
+++ b/legacy_tests/test_mic_dual_timing.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2016-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import xmostest
 

--- a/legacy_tests/test_mic_dual_timing/src/mic_array_conf.h
+++ b/legacy_tests/test_mic_dual_timing/src/mic_array_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef MIC_ARRAY_CONF_H_
 #define MIC_ARRAY_CONF_H_

--- a/legacy_tests/test_mic_dual_timing/src/test_mic_dual_timing.xc
+++ b/legacy_tests/test_mic_dual_timing/src/test_mic_dual_timing.xc
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <stdio.h>
 #include <stdint.h>

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2018-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import os.path
 import pytest

--- a/tests/unit_tests/generate_output/frontend_debug.h
+++ b/tests/unit_tests/generate_output/frontend_debug.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 

--- a/tests/unit_tests/generate_output/mic_array_conf.h
+++ b/tests/unit_tests/generate_output/mic_array_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef MIC_ARRAY_CONF_H_
 #define MIC_ARRAY_CONF_H_

--- a/tests/unit_tests/src/frontend_debug.h
+++ b/tests/unit_tests/src/frontend_debug.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 

--- a/tests/unit_tests/src/test_pdm_muting/mic_array_conf.h
+++ b/tests/unit_tests/src/test_pdm_muting/mic_array_conf.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef MIC_ARRAY_CONF_H_
 #define MIC_ARRAY_CONF_H_


### PR DESCRIPTION
The fixed infr_apps source checker can handle copyright dates that predate the git history, so re-apply the original copyright years.