### PR TITLE
pinned doc builder to v2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       
       - name: Pull doc_builder container
         run: |
-          docker pull ghcr.io/xmos/doc_builder:main 
+          docker pull ghcr.io/xmos/doc_builder:v2.0.0
       
       - name: Build documentation
         run: |


### PR DESCRIPTION
doc_builder v3 will break the documentation build so we need to pin to v2.  Fixes for v3 will be submitted in a separate PR.  