### PR TITLE
Fixes typo in docs workflow.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Save HTML documentation artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lib_mic_array_docs
+          name: lib_mic_array_docs_html
           path: ./doc/_build/html
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
           retention-days: 5
@@ -51,7 +51,7 @@ jobs:
       - name: Save PDF documentation artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lib_xcore_math_docs_pdf
+          name: lib_mic_array_docs_pdf
           path: ./doc/_build/pdf/programming_guide.pdf
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
           retention-days: 5


### PR DESCRIPTION
There was a copy/paste error in the GitHub actions `docs` workflow where the artifact created for the mic array PDF documentation was titled  `lib_xcore_math_docs_pdf`.

Now the two artifacts are `lib_mic_array_docs_html` and `lib_mic_array_docs_pdf`, reflecting the documentation type.

Note: The `upload-artifact` action always zips the artifact, and as far as I can tell there's no way around that. So for users to view the PDF they unfortunately have to download a zip, extract the pdf, and open that.... instead of just opening the PDF directly in the browser.