### PR TITLE
Adds 16-channel support to mic array

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Save HTML documentation artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lib_mic_array_docs
+          name: lib_mic_array_docs_html
           path: ./doc/_build/html
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
           retention-days: 5
@@ -51,7 +51,7 @@ jobs:
       - name: Save PDF documentation artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lib_xcore_math_docs_pdf
+          name: lib_mic_array_docs_pdf
           path: ./doc/_build/pdf/programming_guide.pdf
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
           retention-days: 5

--- a/doc/programming_guide/src/reference/c/util.rst
+++ b/doc/programming_guide/src/reference/c/util.rst
@@ -6,3 +6,5 @@ util.h
 .. doxygenfunction:: deinterleave4
   
 .. doxygenfunction:: deinterleave8
+  
+.. doxygenfunction:: deinterleave16

--- a/lib_mic_array/api/mic_array/util.h
+++ b/lib_mic_array/api/mic_array/util.h
@@ -44,4 +44,17 @@ MA_C_API
 void deinterleave8(uint32_t*);
 
 
+/**
+ * @brief Perform deinterleaving for a 16-microphone subblock.
+ * 
+ * Assembly function. 
+ * 
+ * Deinterleave the samples for 1 subblock of 16 microphones. Argument points to
+ * a 16 word buffer.
+ * 
+ * @ingroup util_h_
+ */
+MA_C_API 
+void deinterleave16(uint32_t*);
+
 C_API_END

--- a/lib_mic_array/src/Util.cpp
+++ b/lib_mic_array/src/Util.cpp
@@ -56,3 +56,16 @@ void mic_array::deinterleave_pdm_samples<8>(
     deinterleave8(sb);
   }
 }
+
+template <>
+void mic_array::deinterleave_pdm_samples<16>(
+    uint32_t* samples,
+    unsigned s2_dec_factor)
+{
+  constexpr unsigned MICS = 16;
+
+  for(int k = 0; k < s2_dec_factor; k++) {
+    uint32_t* sb = &samples[k*MICS];
+    deinterleave16(sb);
+  }
+}

--- a/lib_mic_array/src/deinterleave16.S
+++ b/lib_mic_array/src/deinterleave16.S
@@ -1,0 +1,141 @@
+// Copyright 2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#define NSTACKWORDS   6
+
+.text
+.issue_mode single
+.align 16
+
+
+.globl deinterleave16
+.globl deinterleave16.nstackwords
+.globl deinterleave16.maxthreads
+.globl deinterleave16.maxtimers
+.globl deinterleave16.maxchanends
+.linkset deinterleave16.nstackwords, NSTACKWORDS
+.linkset deinterleave16.threads, 0
+.linkset deinterleave16.maxtimers, 0
+.linkset deinterleave16.chanends, 0
+
+.type deinterleave16, @function
+
+#define   x   r0
+#define   a   r1
+#define   b   r2
+#define   c   r3
+#define   d   r4
+#define   e   r5
+#define   f   r6
+#define   g   r7
+#define   h   r8
+
+
+// r0 points to a double-word-aligned string of 512 = 16 * 32 bits.
+// The bits have indices from 0 to 511, with words at higher addresses holding
+// smaller bit indices, and LSbs of words containing smaller indices than MSbs.
+
+// Then, all bits with index (k mod 16) correspond to microphone channel `k`.
+// The point of this function is to take the bits that started in positions
+// (k mod 16) and collect all 32 of them into word index k, for k in [0,1,..,15]
+
+.cc_top deinterleave16.func,deinterleave16
+deinterleave16:
+  nop
+  entsp NSTACKWORDS
+
+  std r4, r5, sp[0]
+  std r6, r7, sp[1]
+  std r8, r9, sp[2]
+  
+  // Lower half
+  ldd a, b, x[3]
+  ldd c, d, x[2]
+  ldd e, f, x[1]
+  ldd g, h, x[0]
+
+  unzip b, a, 2
+  unzip d, c, 2
+  unzip f, e, 2
+  unzip h, g, 2
+
+  unzip c, a, 1
+  unzip d, b, 1
+  unzip g, e, 1
+  unzip h, f, 1
+
+  unzip e, a, 0
+  unzip f, b, 0
+  unzip g, c, 0
+  unzip h, d, 0
+
+  std e, a, x[0]
+  std g, c, x[1]
+  std f, b, x[2]
+  std h, d, x[3]
+  
+  // Upper half
+  ldd a, b, x[7]
+  ldd c, d, x[6]
+  ldd e, f, x[5]
+  ldd g, h, x[4]
+
+  unzip b, a, 2
+  unzip d, c, 2
+  unzip f, e, 2
+  unzip h, g, 2
+
+  unzip c, a, 1
+  unzip d, b, 1
+  unzip g, e, 1
+  unzip h, f, 1
+
+  unzip e, a, 0
+  unzip f, b, 0
+  unzip g, c, 0
+  unzip h, d, 0
+
+  std e, a, x[4]
+  std g, c, x[5]
+  std f, b, x[6]
+  std h, d, x[7]
+
+
+  ldd a, b, x[0]
+  ldd c, d, x[4]
+  unzip b, d, 0
+  unzip a, c, 0
+  std a, b, x[4]
+  std c, d, x[0]
+
+  ldd a, b, x[1]
+  ldd c, d, x[5]
+  unzip b, d, 0
+  unzip a, c, 0
+  std a, b, x[5]
+  std c, d, x[1]
+
+  ldd a, b, x[2]
+  ldd c, d, x[6]
+  unzip b, d, 0
+  unzip a, c, 0
+  std a, b, x[6]
+  std c, d, x[2]
+
+  ldd a, b, x[3]
+  ldd c, d, x[7]
+  unzip b, d, 0
+  unzip a, c, 0
+  std a, b, x[7]
+  std c, d, x[3]
+
+  ldd r4, r5, sp[0]
+  ldd r6, r7, sp[1]
+  ldd r8, r9, sp[2]
+
+  retsp NSTACKWORDS
+.L_end:
+.cc_bottom deinterleave16.func
+
+
+.size deinterleave16, .L_end - deinterleave16

--- a/tests/unit/src/main.c
+++ b/tests/unit/src/main.c
@@ -13,6 +13,8 @@ int main(int argc, const char* argv[])
   UnityGetCommandLineOptions(argc, argv);
   UnityBegin(argv[0]);
 
+  printf("\n\n");
+
   RUN_TEST_GROUP(dcoe_state_init);
   RUN_TEST_GROUP(dcoe_filter);
   RUN_TEST_GROUP(DcoeSampleFilter);
@@ -25,6 +27,7 @@ int main(int argc, const char* argv[])
   RUN_TEST_GROUP(deinterleave2);
   RUN_TEST_GROUP(deinterleave4);
   RUN_TEST_GROUP(deinterleave8);
+  RUN_TEST_GROUP(deinterleave16);
 
   RUN_TEST_GROUP(deinterleave_pdm_samples);
   

--- a/tests/unit/src/test_deinterleave16.c
+++ b/tests/unit/src/test_deinterleave16.c
@@ -1,0 +1,118 @@
+// Copyright 2020-2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdarg.h>
+
+#include "unity_fixture.h"
+
+#include "mic_array/util.h"
+
+#define CHAN_COUNT    16
+
+TEST_GROUP_RUNNER(deinterleave16) {
+  RUN_TEST_CASE(deinterleave16, case0);
+  RUN_TEST_CASE(deinterleave16, case1);
+}
+
+TEST_GROUP(deinterleave16);
+TEST_SETUP(deinterleave16) {}
+TEST_TEAR_DOWN(deinterleave16) {}
+
+
+/*
+This test ensures that the PDM samples corresponding to channel K end up in
+the kth word after deinterleaving.
+*/
+TEST(deinterleave16, case0)
+{
+
+  for(int k = 0; k < 16; k++){
+    uint32_t vals[CHAN_COUNT] = {0};
+
+    // Set only those bits corresponding to channel k.
+    // after deinterleaving, this should mean each vals[n] == 0, except for
+    // vals[k] == 0xFFFFFFFF
+    for(int n = 0; n < CHAN_COUNT; n++)
+      vals[n] = 0x00010001 << k;
+    
+    // printf("\n\n");
+    // printf("Before:\n");
+    // for(int n = 0; n < CHAN_COUNT/2; n++)
+    //   printf("0x%08X, ", (unsigned) vals[n]);
+    // printf("\n");
+    // for(int n = CHAN_COUNT/2; n < CHAN_COUNT; n++)
+    //   printf("0x%08X, ", (unsigned) vals[n]);
+    // printf("\n\n");
+
+    deinterleave16(&vals[0]);
+
+    // printf("After:\n");
+    // for(int n = 0; n < CHAN_COUNT/2; n++)
+    //   printf("0x%08X, ", (unsigned) vals[n]);
+    // printf("\n");
+    // for(int n = CHAN_COUNT/2; n < CHAN_COUNT; n++)
+    //   printf("0x%08X, ", (unsigned) vals[n]);
+    // printf("\n\n");
+
+    for(int n = 0; n < CHAN_COUNT; n++){
+      uint32_t exp = (n == k) ? 0xFFFFFFFF : 0x00000000;
+      TEST_ASSERT_EQUAL_UINT32_MESSAGE(exp, vals[n], "");
+    }
+
+  }
+}
+
+/*
+This test ensures that the PDM samples within an output word are in the correct
+order.
+*/
+TEST(deinterleave16, case1)
+{
+
+  int p_vals[] = {8, 4, 2, 1};
+
+  for(int p = 0; p < 4; p++){
+
+    uint32_t mask = 0xFFFFFFFF >> (32 - 2*p_vals[p]);
+
+    for(int k = 0; k < CHAN_COUNT; k++){
+      uint32_t vals[CHAN_COUNT] = {0};
+
+      // only set the bits in the higher address words, which correspond to 
+      // earlier samples.
+      for(int n = CHAN_COUNT - p_vals[p]; n < CHAN_COUNT; n++)
+        vals[n] = 0x00010001 << k;
+      
+      // printf("\n\n");
+      // printf("Before:\n");
+      // for(int n = 0; n < CHAN_COUNT/2; n++)
+      //   printf("0x%08X, ", (unsigned) vals[n]);
+      // printf("\n");
+      // for(int n = CHAN_COUNT/2; n < CHAN_COUNT; n++)
+      //   printf("0x%08X, ", (unsigned) vals[n]);
+      // printf("\n\n");
+
+      deinterleave16(&vals[0]);
+
+      // printf("After:\n");
+      // for(int n = 0; n < CHAN_COUNT/2; n++)
+      //   printf("0x%08X, ", (unsigned) vals[n]);
+      // printf("\n");
+      // for(int n = CHAN_COUNT/2; n < CHAN_COUNT; n++)
+      //   printf("0x%08X, ", (unsigned) vals[n]);
+      // printf("\n\n");
+
+      for(int n = 0; n < CHAN_COUNT; n++){
+        uint32_t exp = (n == k) ? mask : 0x00000000;
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(exp, vals[n], "");
+      }
+
+    }
+  }
+}
+


### PR DESCRIPTION
This PR contains fixes necessary to get a 16-channel mic array working.

So far, that includes:
* Implementing `deinterleave16` to split up PDM samples from the different microphones.
