### PR TITLE
Add support for XCommon CMake

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_mic_array change log
 ========================
 
+UNRELEASED
+----------
+
+  * ADDED:   Support for XCommon CMake build system
+
 4.5.0
 -----
 

--- a/lib_mic_array/lib_build_info.cmake
+++ b/lib_mic_array/lib_build_info.cmake
@@ -1,0 +1,13 @@
+set(LIB_NAME lib_mic_array)
+set(LIB_VERSION 4.5.0)
+set(LIB_INCLUDES api src/fir)
+
+# Want to exclude src/fir/make_mic_dual_stage_3_coefs.c
+# There are no other C source files, so set an empty string.
+set(LIB_C_SRCS "")
+
+set(LIB_DEPENDENT_MODULES "lib_xassert"
+                          "lib_logging"
+                          "lib_dsp")
+
+XMOS_REGISTER_MODULE()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@
 # pip-install this one as editable using this repository's setup.py file.  The
 # same modules should appear in the setup.py list as given below.
 flake8==3.8.3
+# Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
+importlib-metadata==4.13.0
+
 matplotlib==3.3.1
 
 # Pin numpy to 1.18.5 due to tensorflow v2.1.1 hard pinning it to that version.


### PR DESCRIPTION
The target branch is a new one I created called `feature/xcommon_cmake` from tag v4.5.0, which I expect to live until we release v4.6.0.

Also needed a Python module version pinned to run the flake8 checks in the Jenkins job (this must have broken after v4.5.0 was released, but I remember making this same change in lots of repos).