### PR TITLE
Add support for XCommon CMake build system on v5.2.0 and above

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_mic_array change log
 ========================
 
+UNRELEASED
+----------
+
+  * ADDED:   Support for XCommon CMake build system on v5.2.0 and above
+
 5.2.0
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ lib_mic_array change log
 UNRELEASED
 ----------
 
-  * ADDED:   Support for XCommon CMake build system on v5.2.0 and above
+  * ADDED:   Support for XCommon CMake build system
 
 5.2.0
 -----
@@ -220,4 +220,3 @@ UNRELEASED
     - lib_logging: Added dependency 2.0.0
 
     - lib_xassert: Added dependency 2.0.0
-

--- a/lib_mic_array/lib_build_info.cmake
+++ b/lib_mic_array/lib_build_info.cmake
@@ -1,0 +1,7 @@
+set(LIB_NAME lib_mic_array)
+set(LIB_VERSION 5.2.0)
+set(LIB_DEPENDENT_MODULES "lib_xcore_math")
+set(LIB_INCLUDES api src src/etc)
+set(LIB_COMPILER_FLAGS -g -Os)
+
+XMOS_REGISTER_MODULE()

--- a/lib_mic_array/lib_build_info.cmake
+++ b/lib_mic_array/lib_build_info.cmake
@@ -1,7 +1,15 @@
 set(LIB_NAME lib_mic_array)
 set(LIB_VERSION 5.2.0)
 set(LIB_DEPENDENT_MODULES "lib_xcore_math")
-set(LIB_INCLUDES api src src/etc)
+set(LIB_INCLUDES 
+    api
+    api/mic_array
+    api/mic_array/cpp
+    api/mic_array/etc
+    api/mic_array/impl
+    src 
+    src/etc
+)
 set(LIB_COMPILER_FLAGS -g -Os)
 
 XMOS_REGISTER_MODULE()

--- a/lib_mic_array/lib_build_info.cmake
+++ b/lib_mic_array/lib_build_info.cmake
@@ -1,6 +1,6 @@
 set(LIB_NAME lib_mic_array)
 set(LIB_VERSION 5.2.0)
-set(LIB_DEPENDENT_MODULES "lib_xcore_math")
+set(LIB_DEPENDENT_MODULES "lib_xcore_math(2.2.0)")
 set(LIB_INCLUDES 
     api
     api/mic_array


### PR DESCRIPTION
Closes: [LSM-46](https://xmosjira.atlassian.net/browse/LSM-46)

[LSM-46]: https://xmosjira.atlassian.net/browse/LSM-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ