### PR TITLE
Bump to 5.4.0 and improve test robustness

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,9 @@
 lib_mic_array change log
 ========================
 
-5.3.0
+5.4.0
 -----
 
-  * FIXED:   Vanilla configuration now compiles correctly under XTC 15.3.0
-  * ADDED:   Support for XCommon CMake build system
   * CHANGED: All examples now build under XCommon CMake build system
   * ADDED:   Will build without errors for XS2 targets but no API available
   * DEPRECATED: Previously used custom CMake build support. This will be removed
@@ -15,6 +13,12 @@ lib_mic_array change log
   * Changes to dependencies:
 
     - lib_xcore_math: 2.0.0 -> 2.2.0
+
+5.3.0
+-----
+
+  * FIXED:   Vanilla configuration now compiles correctly under XTC 15.3.0
+  * ADDED:   Support for XCommon CMake build system
 
 5.2.0
 -----

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
                 }
                 stage('HW tests') {
                     agent {
-                        label 'xcore.ai'
+                        label 'xcore.ai || xvf3800'
                     }
                     stages {
                         stage("Checkout and Build") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,13 +182,13 @@ pipeline {
                                             // note no xdist for HW tests as only 1 hw instance
                                             // Each test has it's own conftest.py so we need to run these seprarately
                                             dir("signal/BasicMicArray") {
-                                                runPytest('-s -vv --numprocesses=1')
+                                                runPytest('-vv --numprocesses=1')
                                             }
                                             dir("signal/TwoStageDecimator") {
-                                                runPytest('-s -vv --numprocesses=1')
+                                                runPytest('-vv --numprocesses=1')
                                             }
                                             dir("signal/FilterDesign") {
-                                                runPytest('-s -vv')
+                                                runPytest('-vv')
                                             }
                                         }
                                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
                 }
                 stage('HW tests') {
                     agent {
-                        label 'xvf3800' // We have plenty of these (6) and they have a single XTAG connected
+                        label 'xcore.ai'
                     }
                     stages {
                         stage("Checkout and Build") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
       
                                             // Run this first to ensure the XTAG is up and running for subsequent tests
                                             timeout(time: 2, unit: 'MINUTES') {
-                                                sh "xrun --xscope unit/bin/tests-unit.xe"
+                                                sh "xrun --xscope --id 0 unit/bin/tests-unit.xe"
                                             }
                                             
                                             // note no xdist for HW tests as only 1 hw instance

--- a/lib_mic_array/lib_build_info.cmake
+++ b/lib_mic_array/lib_build_info.cmake
@@ -1,5 +1,5 @@
 set(LIB_NAME lib_mic_array)
-set(LIB_VERSION 5.3.0)
+set(LIB_VERSION 5.4.0)
 set(LIB_DEPENDENT_MODULES "lib_xcore_math(2.2.0)")
 set(LIB_INCLUDES 
     api

--- a/lib_mic_array/module_build_info
+++ b/lib_mic_array/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 5.3.0
+VERSION = 5.4.0
 
 DEPENDENT_MODULES = lib_xcore_math(>=2.2.0)
 

--- a/script/mic_array/device_context.py
+++ b/script/mic_array/device_context.py
@@ -9,11 +9,11 @@ class DeviceContext(object):
   
   XRUN_CMD_BASE = ('xrun', '--xscope', '--xscope-port','localhost:10234')
 
-  def __init__(self, xe_path, /, probes=[], **kwargs):
+  def __init__(self, xe_path, /, probes=[], extra_xrun_args="", **kwargs):
     
     self.xe_path = xe_path
 
-    self.xrun_cmd = list(DeviceContext.XRUN_CMD_BASE) + [self.xe_path]
+    self.xrun_cmd = list(DeviceContext.XRUN_CMD_BASE) + extra_xrun_args.split() + [self.xe_path]
     self.xrun = None
 
     self.ep = xscope.Endpoint()

--- a/settings.yml
+++ b/settings.yml
@@ -2,7 +2,7 @@
 lib_name: lib_mic_array
 project: '{{lib_name}}'
 title: '{{lib_name}}: XMOS I2S Library'
-version: 5.3.0
+version: 5.4.0
 
 documentation:
   exclude_patterns_path: doc/exclude_patterns.inc

--- a/tests/signal/BasicMicArray/micarray_device.py
+++ b/tests/signal/BasicMicArray/micarray_device.py
@@ -1,4 +1,4 @@
-# Copyright 2022 XMOS LIMITED.
+# Copyright 2022-2024 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
  
 

--- a/tests/signal/BasicMicArray/micarray_device.py
+++ b/tests/signal/BasicMicArray/micarray_device.py
@@ -10,8 +10,8 @@ from mic_array.pdm_signal import PdmSignal
 
 class MicArrayDevice(DeviceContext):
   
-  def __init__(self, xe_path, /, **kwargs):
-    super().__init__(xe_path, probes=["meta_out", "data_out"], **kwargs)
+  def __init__(self, xe_path, /, extra_xrun_args="", **kwargs):
+    super().__init__(xe_path, probes=["meta_out", "data_out"], extra_xrun_args=extra_xrun_args, **kwargs)
 
     self.channels = None # unknown initially
 

--- a/tests/signal/BasicMicArray/src/app.cpp
+++ b/tests/signal/BasicMicArray/src/app.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 XMOS LIMITED.
+// Copyright 2022-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <iostream>

--- a/tests/signal/BasicMicArray/src/app.h
+++ b/tests/signal/BasicMicArray/src/app.h
@@ -1,4 +1,4 @@
-// Copyright 2022 XMOS LIMITED.
+// Copyright 2022-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #pragma once

--- a/tests/signal/BasicMicArray/src/app.h
+++ b/tests/signal/BasicMicArray/src/app.h
@@ -19,9 +19,13 @@ void app_pdm_rx_isr_setup(chanend_t c_from_host);
 MA_C_API
 void app_pdm_task(chanend_t sc_mics);
 
-// Thread that sends results back to host
+// Thread that receives samples and pushes them into a FIFO
 MA_C_API
-void app_output_task(chanend_t c_frames_in);
+void app_output_task(chanend_t c_frames_in, chanend_t c_fifo);
+
+// Thread that sends FIFO results back to host
+MA_C_API
+void app_fifo_to_xscope_task(chanend_t c_fifo);
 
 // Print filters (for debug purposes)
 MA_C_API

--- a/tests/signal/BasicMicArray/src/main.xc
+++ b/tests/signal/BasicMicArray/src/main.xc
@@ -141,6 +141,7 @@ int main()
   chan c_from_host;
   streaming chan c_to_app;
   chan c_frames;
+  chan c_fifo;
 
   par {
     xscope_host_data(c_from_host);
@@ -150,9 +151,8 @@ int main()
     }
 
     on tile[0]: {
-      xscope_mode_lossy(); // This was lossless but this was causing occasional test failures as app_output_task() couldn't
-                           // output all data in time on 8 mics, 16 frame. No data appears to be lost and tests pass.
-
+      xscope_mode_lossless();
+      
 #if (USE_ISR)
       app_pdm_rx_isr_setup((chanend_t) c_to_app);
 #endif
@@ -162,7 +162,8 @@ int main()
         app_pdm_task((chanend_t) c_to_app);
 #endif
         app_dec_task((chanend_t) c_frames);
-        app_output_task((chanend_t) c_frames);
+        app_output_task((chanend_t) c_frames, (chanend_t)c_fifo);
+        app_fifo_to_xscope_task((chanend_t)c_fifo);
       }
     }
   }

--- a/tests/signal/BasicMicArray/test_mic_array.py
+++ b/tests/signal/BasicMicArray/test_mic_array.py
@@ -121,7 +121,7 @@ class Test_BasicMicArray(object):
     if self.print_output: print(f"Expected output: {expected}")
 
     ## Now see what the device says.
-    with MicArrayDevice(xe_path, quiet_xgdb=not self.print_xgdb) as dev:
+    with MicArrayDevice(xe_path, quiet_xgdb=not self.print_xgdb, extra_xrun_args="--id 0") as dev:
 
       # Make sure we're talking to the correct application
       assert dev.param["channels"] == chans

--- a/tests/signal/TwoStageDecimator/decimator_device.py
+++ b/tests/signal/TwoStageDecimator/decimator_device.py
@@ -10,8 +10,8 @@ from mic_array.pdm_signal import PdmSignal
 
 class DecimatorDevice(DeviceContext):
   
-  def __init__(self, xe_path, /, **kwargs):
-    super().__init__(xe_path, probes=["meta_out", "data_out"], **kwargs)
+  def __init__(self, xe_path, /, extra_xrun_args="", **kwargs):
+    super().__init__(xe_path, probes=["meta_out", "data_out"], extra_xrun_args=extra_xrun_args, **kwargs)
 
     self.channels = None # unknown initially
 

--- a/tests/signal/TwoStageDecimator/test_stage1.py
+++ b/tests/signal/TwoStageDecimator/test_stage1.py
@@ -81,7 +81,7 @@ class Test_Stage1(object):
     if self.print_out: print(f"Expected output: {expected}")
 
     ## Now see what the device says.
-    with DecimatorDevice(xe_path) as dev:
+    with DecimatorDevice(xe_path, extra_xrun_args="--id 0") as dev:
 
       assert dev.param["channels"] == chans
       assert dev.param["s1.dec_factor"] == 32

--- a/tests/signal/TwoStageDecimator/test_stage2.py
+++ b/tests/signal/TwoStageDecimator/test_stage2.py
@@ -86,7 +86,7 @@ class Test_Stage2(object):
     if self.print_out: print(f"Expected output: {expected}")
 
     ## Now see what the device says.
-    with DecimatorDevice(xe_path) as dev:
+    with DecimatorDevice(xe_path, extra_xrun_args="--id 0") as dev:
 
       assert dev.param["channels"] == chans
       assert dev.param["s1.dec_factor"] == 32


### PR DESCRIPTION
Add FIFO to decouple xscope writes in test. Works around occasional error such as:

Build and Docs / HW tests / Run tests / test_BasicMicArray[1_isr-16frame-8n_mics] – test_mic_array.Test_BasicMicArray

Also changes to support broader range of executors as often waiting for 3800 jobs

Note - there was an issue where v5.3.0 was tagged and released but not marked as latest release hence not bumping version before as I though 5.2.0 was latest.