### PR TITLE
Remove explicit warning when being built under XS2

### DIFF
--- a/lib_mic_array/api/mic_array.h
+++ b/lib_mic_array/api/mic_array.h
@@ -3,9 +3,7 @@
 #pragma once
 
 #ifdef __XS3A__ // Only available for xcore.ai
-#include "mic_array/api.h"
-#else
-#warning "lib_mic_array is being built using a target other than XS3 (xcore.ai). This library only supports XS3. Please use version <5.0.0 for XS2 support."  
+#include "mic_array/api.h"  
 #endif // __XS3A__
 #include "mic_array/pdm_resources.h"
 #include "mic_array/dc_elimination.h"


### PR DESCRIPTION
To reduce build noise in sw_usb_audio/xua