### PR TITLE
Update lib_mic_array.rst header formatting

### DIFF
--- a/doc/rst/lib_mic_array.rst
+++ b/doc/rst/lib_mic_array.rst
@@ -1,8 +1,8 @@
 .. lib_mic_array documentation master file
 
-#############
+###########################################
 lib_mic_array: PDM microphone array library
-#############
+###########################################
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
xmosdoc complains about title line "Title overline too short."
