### PR TITLE
Remove flash info from .xn files

### DIFF
--- a/examples/app_measure_mips/XVF3610_Q60A.xn
+++ b/examples/app_measure_mips/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/examples/app_mic_array/XVF3610_Q60A.xn
+++ b/examples/app_mic_array/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/examples/app_vanilla/XVF3610_Q60A.xn
+++ b/examples/app_vanilla/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/tests/app_regular_xcommon_build/src/XVF3610_Q60A.xn
+++ b/tests/app_regular_xcommon_build/src/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/tests/app_vanilla_xcommon_build/src/XVF3610_Q60A.xn
+++ b/tests/app_vanilla_xcommon_build/src/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/tests/custom_cmake_build/prefab/XVF3610_Q60A.xn
+++ b/tests/custom_cmake_build/prefab/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/tests/custom_cmake_build/vanilla/XVF3610_Q60A.xn
+++ b/tests/custom_cmake_build/vanilla/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/tests/signal/BasicMicArray/XVF3610_Q60A.xn
+++ b/tests/signal/BasicMicArray/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>

--- a/tests/signal/TwoStageDecimator/XVF3610_Q60A.xn
+++ b/tests/signal/TwoStageDecimator/XVF3610_Q60A.xn
@@ -77,7 +77,7 @@
     </Link>
   </Links>
   <ExternalDevices>
-    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" Type="S25FL116K" PageSize="256" SectorSize="4096" NumPages="16384">
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash">
       <Attribute Name="PORT_SQI_CS" Value="PORT_SQI_CS_0"/>
       <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK_0"/>
       <Attribute Name="PORT_SQI_SIO" Value="PORT_SQI_SIO_0"/>


### PR DESCRIPTION
From [LSM-100](https://xmosjira.atlassian.net/browse/LSM-100).

Since XTC 15.2.1, we use SFDP to get information about the flash chip on the board, so including this information in the `.xn` files is no longer necessary. This PR removes that information from those files so tools like `xflash` don't give warnings that this information is present.

[LSM-100]: https://xmosjira.atlassian.net/browse/LSM-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ