### PR TITLE
Fix small changelog error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,6 @@ lib_mic_array change log
   * FIXED: PDM RX ISR deadlock bug
   * REMOVED: Vanilla API and configuration
   * REMOVED: Prefab API
-  * REMOVED: lib_xassert dependency
 
 5.5.0
 -----


### PR DESCRIPTION
Removed lib_xassert dependency from the changelog.