### PR TITLE
Add support for running decimator stage-2 in a separate thread for low power mic configurations.

### DIFF
--- a/lib_mic_array/api/mic_array.h
+++ b/lib_mic_array/api/mic_array.h
@@ -14,6 +14,7 @@
 #include "mic_array/mic_array_conf_struct.h"
 #include "mic_array/mic_array_task.h"
 #include "mic_array/mic_array_conf_full.h"
+#include "mic_array/decimator_stg2_task.h"
 
 #ifdef __cplusplus
 # include "mic_array/cpp/Decimator.hpp"

--- a/lib_mic_array/api/mic_array/cpp/Decimator.hpp
+++ b/lib_mic_array/api/mic_array/cpp/Decimator.hpp
@@ -65,6 +65,10 @@ class TwoStageDecimator
       unsigned pdm_history_sz;
     } stage1;
 
+  public:
+    chanend_t c_decimator;
+    constexpr TwoStageDecimator() noexcept { }
+
     /**
      * Stage 2 decimation configuration and state.
      */
@@ -78,10 +82,6 @@ class TwoStageDecimator
        */
       unsigned decimation_factor;
     } stage2;
-
-  public:
-
-    constexpr TwoStageDecimator() noexcept { }
 
     /**
      * @brief Initialize the two-stage decimator from a configuration struct
@@ -127,8 +127,33 @@ class TwoStageDecimator
         int32_t sample_out[MIC_COUNT],
         uint32_t *pdm_block);
 
+    /**
+     * @brief Process a single mic, 2 sample PDM block using only the 1st stage decimation filters
+     *
+     * Consumes two PDM words from `pdm_block` and runs the
+     * stage-1 FIR twice. Two output samples are written to
+     * `sample_out[0]` and `sample_out[1]`. This path is used in low-power
+     * configurations where only the stage-1 filter is active.
+     *
+     * @param sample_out  Output sample vector with two consecutive samples.
+     * @param pdm_block   PDM data to be processed (two words).
+     */
     void ProcessBlockSingleStage(
         int32_t sample_out[2][MIC_COUNT],
+        uint32_t *pdm_block);
+
+    /**
+     * @brief Process a single mic, 2 sample PDM block using 1st and 2nd stage decimation filters
+     * where the 2nd stage filter runs in a different thread.
+     *
+     * This path is used in low-power
+     * configurations where both 1st and 2nd stage filters are active.
+     *
+     * @param sample_out  Output sample vector (one sample).
+     * @param pdm_block   PDM data to be processed (two words).
+     */
+    void ProcessBlockParTwoStage(
+        int32_t sample_out[MIC_COUNT],
         uint32_t *pdm_block);
   };
 }
@@ -193,6 +218,25 @@ void mic_array::TwoStageDecimator<MIC_COUNT>
 
   hist[0] = pdm_block[1];
   sample_out[1][0] = fir_1x16_bit(hist, this->stage1.filter_coef);
+  shift_buffer(hist);
+}
+
+template <unsigned MIC_COUNT>
+void mic_array::TwoStageDecimator<MIC_COUNT>
+    ::ProcessBlockParTwoStage(
+        int32_t sample_out[MIC_COUNT],
+        uint32_t *pdm_block)
+{
+  uint32_t* hist = this->stage1.pdm_history_ptr;
+  sample_out[0] = chanend_in_word(c_decimator);
+  hist[0] = pdm_block[0];
+  int32_t streamA_sample = fir_1x16_bit(hist, this->stage1.filter_coef);
+  chanend_out_word(this->c_decimator, streamA_sample);
+  shift_buffer(hist);
+
+  hist[0] = pdm_block[1];
+  streamA_sample = fir_1x16_bit(hist, this->stage1.filter_coef);
+  chanend_out_word(this->c_decimator, streamA_sample);
   shift_buffer(hist);
 }
 

--- a/lib_mic_array/api/mic_array/cpp/MicArray.hpp
+++ b/lib_mic_array/api/mic_array/cpp/MicArray.hpp
@@ -178,7 +178,28 @@ namespace  mic_array {
        */
       void ThreadEntry();
 
-      void ThreadEntryLowPower();
+      /**
+       * @brief Entry point for the low-power single-stage decimation thread.
+       *
+       * This function loops, collecting PDM
+       * blocks from @ref PdmRx and running the single-stage decimator. Each
+       * block produces two output samples which are delivered sequentially
+       * through @ref OutputHandler. On shutdown it calls @ref PdmRx::Shutdown()
+       * and then completes the output shutdown handshake.
+       */
+      void ThreadEntryLowPower_1StgDecimator();
+
+      /**
+       * @brief Entry point for the low-power two-stage decimation thread.
+       *
+       * This function loops indefinitely, collecting PDM
+       * blocks from @ref PdmRx and running the parallel two-stage decimator.
+       * Each block produces one output sample which is delivered through @ref
+       * OutputHandler. On shutdown it stops the stage-2 decimator task via the
+       * `Decimator.c_decimator` channel, calls @ref PdmRx::Shutdown(), and then
+       * completes the output shutdown handshake.
+       */
+      void ThreadEntryLowPower_2StgDecimator();
   };
 
 }
@@ -218,7 +239,7 @@ template <unsigned MIC_COUNT,
           class TOutputHandler>
 void mic_array::MicArray<MIC_COUNT,TDecimator,TPdmRx,
                                    TSampleFilter,
-                                   TOutputHandler>::ThreadEntryLowPower()
+                                   TOutputHandler>::ThreadEntryLowPower_1StgDecimator()
 {
   int32_t sample_out[2][MIC_COUNT] = {{0}};
   volatile bool shutdown = false;
@@ -230,6 +251,32 @@ void mic_array::MicArray<MIC_COUNT,TDecimator,TPdmRx,
     shutdown = OutputHandler.OutputSample(sample_out[1]);
   }
   PdmRx.Shutdown();
+  OutputHandler.CompleteShutdown(); // Exchange end token with the app to close channel and indicate completion.
+                                    // ma_shutdown() will now return
+  return;
+}
+
+template <unsigned MIC_COUNT,
+          class TDecimator,
+          class TPdmRx,
+          class TSampleFilter,
+          class TOutputHandler>
+void mic_array::MicArray<MIC_COUNT,TDecimator,TPdmRx,
+                                   TSampleFilter,
+                                   TOutputHandler>::ThreadEntryLowPower_2StgDecimator()
+{
+  int32_t sample_out[MIC_COUNT] = {{0}};
+  volatile bool shutdown = false;
+
+  while(!shutdown){
+    uint32_t *pdm_samples = PdmRx.GetPdmBlock();
+    Decimator.ProcessBlockParTwoStage(sample_out, pdm_samples);
+    shutdown = OutputHandler.OutputSample(sample_out);
+  }
+  PdmRx.Shutdown();
+  // shutdown decimator_stg2_task
+  chanend_out_control_token(Decimator.c_decimator, XS1_CT_END);
+  chan_free(Decimator.c_decimator);
   OutputHandler.CompleteShutdown(); // Exchange end token with the app to close channel and indicate completion.
                                     // ma_shutdown() will now return
   return;

--- a/lib_mic_array/api/mic_array/decimator_stg2_task.h
+++ b/lib_mic_array/api/mic_array/decimator_stg2_task.h
@@ -1,0 +1,13 @@
+// Copyright 2026 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#pragma once
+
+#include <stdint.h>
+#include "xmath/xmath.h"
+
+C_API_START
+
+MA_C_API
+void decimator_stg2_task(chanend_t c_decimator, filter_fir_s32_t *filters, const unsigned decimation_factor);
+
+C_API_END

--- a/lib_mic_array/api/mic_array/mic_array_conf_default.h
+++ b/lib_mic_array/api/mic_array/mic_array_conf_default.h
@@ -60,14 +60,29 @@
 #ifndef MIC_ARRAY_CONFIG_USE_DC_ELIMINATION
 # define MIC_ARRAY_CONFIG_USE_DC_ELIMINATION    (1)
 #endif
-
-/** @brief Enable Low power mode of the mic array.
- * In low power mode, only a single stage decimator is run.
- * Note that PDM RX is still expected to output 2 samples to the decimator
+/** @brief Enable low power mode for the microphone array.
+ *
+ * In low power mode only the first-stage decimator filter is executed.
+ *
+ * Note: PDM RX still outputs two samples to the decimator pipeline.
+ *
  * Default: 0
-*/
+ */
 #ifndef MIC_ARRAY_CONFIG_LOW_POWER
-# define MIC_ARRAY_CONFIG_LOW_POWER    (0)
+# define MIC_ARRAY_CONFIG_LOW_POWER (0)
 #endif
 
+
+/** @brief Run the second-stage decimator filter in a separate task.
+ *
+ * This option is only relevant when MIC_ARRAY_CONFIG_LOW_POWER == 1.
+ *
+ * When enabled, the stage-2 decimator filter runs in a separate thread.
+ * When disabled (with MIC_ARRAY_CONFIG_LOW_POWER == 1), the stage-2 filter is not run.
+ *
+ * Default: 0
+ */
+#ifndef MIC_ARRAY_CONFIG_ENABLE_DECIMATOR_STG2_TASK
+# define MIC_ARRAY_CONFIG_ENABLE_DECIMATOR_STG2_TASK (0)
+#endif
 #endif // _MIC_ARRAY_CONF_DEFAULT_H_

--- a/lib_mic_array/src/decimator_stg2_task.c
+++ b/lib_mic_array/src/decimator_stg2_task.c
@@ -1,0 +1,33 @@
+// Copyright 2026 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include <xs1.h>
+#include <platform.h>
+#include <stdint.h>
+
+#include "xmath/xmath.h"
+#include "xcore/chanend.h"
+#include "xcore/select.h"
+
+void decimator_stg2_task(chanend_t c_decimator, filter_fir_s32_t *filters, const unsigned decimation_factor)
+{
+    chanend_out_word(c_decimator, 0);
+     SELECT_RES(
+        CASE_THEN(c_decimator, event_new_sample)
+    )
+    {
+        event_new_sample:
+        {
+            unsigned shutdown = chanend_test_control_token_next_byte(c_decimator);
+            if(shutdown) {
+                break;
+            }
+            int32_t sample0 = chanend_in_word(c_decimator);
+            filter_fir_s32_add_sample(&filters[0], sample0);
+            int32_t sample1 = chanend_in_word(c_decimator);
+            int32_t sample_out = filter_fir_s32(&filters[0], sample1);
+            chanend_out_word(c_decimator, sample_out);
+            continue;
+        }
+    }
+}

--- a/lib_mic_array/src/mic_array_task.c
+++ b/lib_mic_array/src/mic_array_task.c
@@ -52,10 +52,16 @@ void default_ma_task_start_pdm(void)
   start_pdm_task();
 }
 
-DECLARE_JOB(default_ma_task_start_decimator, (void));
-void default_ma_task_start_decimator(void)
+DECLARE_JOB(default_ma_task_start_decimator, (chanend_t));
+void default_ma_task_start_decimator(chanend_t c_decimator)
 {
-  start_decimator_task();
+  start_decimator_task(c_decimator);
+}
+
+DECLARE_JOB(default_ma_task_decimator_stg2, (chanend_t));
+void default_ma_task_decimator_stg2(chanend_t c_decimator)
+{
+  start_decimator_stg2_task(c_decimator);
 }
 
 DECLARE_JOB(default_ma_task_start_pdm_3stg, (void));
@@ -82,11 +88,19 @@ void mic_array_start(chanend_t c_frames_out)
       PJOB(default_ma_task_start_pdm_3stg, ()),
       PJOB(default_ma_task_start_decimator_3stg, ()));
   } else {
+#if (MIC_ARRAY_CONFIG_LOW_POWER && MIC_ARRAY_CONFIG_ENABLE_DECIMATOR_STG2_TASK)
+    channel_t c_decimator = chan_alloc();
     PAR_JOBS(
       PJOB(default_ma_task_start_pdm, ()),
-      PJOB(default_ma_task_start_decimator, ()));
+      PJOB(default_ma_task_start_decimator, (c_decimator.end_a)),
+      PJOB(default_ma_task_decimator_stg2, (c_decimator.end_b))
+    );
+#else
+    PAR_JOBS(
+      PJOB(default_ma_task_start_pdm, ()),
+      PJOB(default_ma_task_start_decimator, (0)));
+#endif
   }
 #endif // MIC_ARRAY_CONFIG_USE_PDM_ISR
-
   shutdown_mic_array();
 }

--- a/lib_mic_array/src/mic_array_task.cpp
+++ b/lib_mic_array/src/mic_array_task.cpp
@@ -189,13 +189,25 @@ void start_pdm_task(void)
   s_mics->PdmRx.ThreadEntry();
 }
 
-void start_decimator_task(void)
+void start_decimator_task(chanend_t c_decimator)
 {
 #if MIC_ARRAY_CONFIG_LOW_POWER
-  s_mics->ThreadEntryLowPower();
+#if MIC_ARRAY_CONFIG_ENABLE_DECIMATOR_STG2_TASK
+  s_mics->Decimator.c_decimator = c_decimator;
+  s_mics->ThreadEntryLowPower_2StgDecimator();
+#else
+  s_mics->ThreadEntryLowPower_1StgDecimator();
+#endif
 #else
   s_mics->ThreadEntry();
 #endif
+}
+
+void start_decimator_stg2_task(chanend_t c_decimator)
+{
+  filter_fir_s32_t *filters = s_mics->Decimator.stage2.filters;
+  unsigned decimation_factor = s_mics->Decimator.stage2.decimation_factor;
+  decimator_stg2_task(c_decimator, filters, decimation_factor);
 }
 
 void start_pdm_task_3stg(void)

--- a/lib_mic_array/src/mic_array_task_internal.hpp
+++ b/lib_mic_array/src/mic_array_task_internal.hpp
@@ -106,7 +106,10 @@ MA_C_API
 void shutdown_mic_array(void);
 
 MA_C_API
-void start_decimator_task(void);
+void start_decimator_task(chanend_t c_decimator);
+
+MA_C_API
+void start_decimator_stg2_task(chanend_t c_decimator);
 
 MA_C_API
 void start_decimator_task_3stg(void);


### PR DESCRIPTION
Enabled by defining -DMIC_ARRAY_CONFIG_ENABLE_DECIMATOR_STG2_TASK=1, in addition to -DMIC_ARRAY_CONFIG_LOW_POWER=1